### PR TITLE
Improve filtering

### DIFF
--- a/src/Filters.tsx
+++ b/src/Filters.tsx
@@ -25,6 +25,12 @@ display: block;
 margin-bottom: 0.1em;
 `)
 
+const unitsCss = css(`
+float: right;
+color: #535863;
+padding: 0px 20px 0px 0px;
+`)
+
 // const newTables = prevState.tables
 // newTables.push({file: file, index: index, desc: desc})
 // return {state: prevFilter.state, tables: newTables}
@@ -62,10 +68,10 @@ function Filters({filter, setFilter}: FiltersProps): JSX.Element {
     {
       group: 'Colonies',
       items: [
-        {name: 'All', file: 'numbers', index: 1, units: 'colonies'},
-        {name: 'Lost', file: 'numbers', index: 3, units: 'colonies'},
-        {name: 'Renovated', file: 'numbers', index: 6, units: 'colonies'},
-        {name: 'Honey Producing', file: 'honey', index: 1, units: 'colonies'},
+        {name: 'All', file: 'numbers', index: 1, units: '#'},
+        {name: 'Lost', file: 'numbers', index: 3, units: '#'},
+        {name: 'Renovated', file: 'numbers', index: 6, units: '#'},
+        {name: 'Honey Producing', file: 'honey', index: 1, units: '#'},
       ],
     },
     {
@@ -111,6 +117,7 @@ function Filters({filter, setFilter}: FiltersProps): JSX.Element {
                 disabled={filterTypes.length === 2 && !filterTypes.includes(units)}
               />{' '}
               {name}
+              <label css={unitsCss}>{units}</label>
             </label>
           ))}
         </section>

--- a/src/Filters.tsx
+++ b/src/Filters.tsx
@@ -3,9 +3,7 @@ import {css} from '@emotion/core'
 
 export interface Filter {
   state: string
-  file: string
-  index: number
-  desc: string
+  tables: {file: string; index: number; desc: string}[]
 }
 
 interface FiltersProps {
@@ -27,11 +25,30 @@ display: block;
 margin-bottom: 0.1em;
 `)
 
+// const newTables = prevState.tables
+// newTables.push({file: file, index: index, desc: desc})
+// return {state: prevFilter.state, tables: newTables}
+
 function Filters({filter, setFilter}: FiltersProps): JSX.Element {
+  const [filterTypes, setFilterTypes] = React.useState([])
   const onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const {checked} = event.target
     const {file, index, desc} = event.target.dataset
     if (file && index) {
-      setFilter((filter) => ({...filter, file, desc, index: +index}))
+      setFilter((prevFilter) => {
+        const newTables = prevFilter.tables
+        if (checked) {
+          newTables.push({file, index, desc})
+        } else {
+          for (let i = 0; i < newTables.length; i++) {
+            if (newTables[i].desc === desc) {
+              newTables.splice(i, 1)
+              break
+            }
+          }
+        }
+        return {state: prevFilter.state, tables: newTables}
+      })
     }
   }
 
@@ -39,31 +56,31 @@ function Filters({filter, setFilter}: FiltersProps): JSX.Element {
     {
       group: 'Colonies',
       items: [
-        {name: 'All', file: 'numbers', index: 1},
-        {name: 'Lost', file: 'numbers', index: 3},
-        {name: 'Renovated', file: 'numbers', index: 6},
-        {name: 'Honey Producing', file: 'honey', index: 1},
+        {name: 'All', file: 'numbers', index: 1, units: 'colonies'},
+        {name: 'Lost', file: 'numbers', index: 3, units: 'colonies'},
+        {name: 'Renovated', file: 'numbers', index: 6, units: 'colonies'},
+        {name: 'Honey Producing', file: 'honey', index: 1, units: 'colonies'},
       ],
     },
     {
       group: 'Honey',
       items: [
-        {name: 'Yield', file: 'honey', index: 2},
-        {name: 'Production', file: 'honey', index: 3},
-        {name: 'Stocks', file: 'honey', index: 4},
-        {name: 'Price / Pound', file: 'honey', index: 5},
-        {name: 'Value of Production', file: 'honey', index: 6},
+        {name: 'Yield', file: 'honey', index: 2, units: 'lbs'},
+        {name: 'Production', file: 'honey', index: 3, units: 'lbs'},
+        {name: 'Stocks', file: 'honey', index: 4, units: 'lbs'},
+        {name: 'Price / Pound', file: 'honey', index: 5, units: '$'},
+        {name: 'Value of Production', file: 'honey', index: 6, units: '$'},
       ],
     },
     {
       group: 'Stressors',
       items: [
-        {name: 'Varroa mites', file: 'stressors', index: 1},
-        {name: 'Other Pests', file: 'stressors', index: 2},
-        {name: 'Diseases', file: 'stressors', index: 3},
-        {name: 'Pesticides', file: 'stressors', index: 4},
-        {name: 'Other', file: 'stressors', index: 5},
-        {name: 'Unknown', file: 'stressors', index: 6},
+        {name: 'Varroa mites', file: 'stressors', index: 1, units: '%'},
+        {name: 'Other Pests', file: 'stressors', index: 2, units: '%'},
+        {name: 'Diseases', file: 'stressors', index: 3, units: '%'},
+        {name: 'Pesticides', file: 'stressors', index: 4, units: '%'},
+        {name: 'Other', file: 'stressors', index: 5, units: '%'},
+        {name: 'Unknown', file: 'stressors', index: 6, units: '%'},
       ],
     },
   ]
@@ -75,13 +92,16 @@ function Filters({filter, setFilter}: FiltersProps): JSX.Element {
           {items.map(({file, index, name}) => (
             <label key={file + index} css={label}>
               <input
-                type="radio"
+                type="checkbox"
                 name="column"
                 onChange={onChange}
-                checked={filter.file === file && index === filter.index}
+                checked={
+                  filter.tables && filter.tables.filter((table) => table.desc === name).length === 1
+                }
                 data-desc={name}
                 data-file={file}
                 data-index={index}
+                disabled={false}
               />{' '}
               {name}
             </label>

--- a/src/Filters.tsx
+++ b/src/Filters.tsx
@@ -12,6 +12,7 @@ interface FiltersProps {
 }
 
 const section = css(`
+min-width: 225px;
 margin-bottom: 1em;
 strong {
 font-variant: small-caps;

--- a/src/Filters.tsx
+++ b/src/Filters.tsx
@@ -3,7 +3,7 @@ import {css} from '@emotion/core'
 
 export interface Filter {
   state: string
-  tables: {file: string; index: number; desc: string}[]
+  tables: {file: string; index: number; desc: string; units: string}[]
 }
 
 interface FiltersProps {
@@ -33,13 +33,19 @@ function Filters({filter, setFilter}: FiltersProps): JSX.Element {
   const [filterTypes, setFilterTypes] = React.useState([])
   const onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const {checked} = event.target
-    const {file, index, desc} = event.target.dataset
+    const {file, index, desc, units} = event.target.dataset
     if (file && index) {
       setFilter((prevFilter) => {
         const newTables = prevFilter.tables
         if (checked) {
-          newTables.push({file, index, desc})
+          newTables.push({file, index, desc, units})
+          if (!filterTypes.includes(units)) {
+            filterTypes.push(units)
+          }
         } else {
+          if (newTables.filter((table) => table.units === units).length === 1) {
+            filterTypes.splice(filterTypes.indexOf(units), 1)
+          }
           for (let i = 0; i < newTables.length; i++) {
             if (newTables[i].desc === desc) {
               newTables.splice(i, 1)
@@ -89,7 +95,7 @@ function Filters({filter, setFilter}: FiltersProps): JSX.Element {
       {filterDefs.map(({group, items}) => (
         <section css={section} key={group}>
           <strong>{group}</strong>
-          {items.map(({file, index, name}) => (
+          {items.map(({file, index, name, units}) => (
             <label key={file + index} css={label}>
               <input
                 type="checkbox"
@@ -101,7 +107,8 @@ function Filters({filter, setFilter}: FiltersProps): JSX.Element {
                 data-desc={name}
                 data-file={file}
                 data-index={index}
-                disabled={false}
+                data-units={units}
+                disabled={filterTypes.length === 2 && !filterTypes.includes(units)}
               />{' '}
               {name}
             </label>


### PR DESCRIPTION
Allow the user to select as many filters as they want so long as the filters involve <= 2 different types.

Also updated the `Filter` interface to support multiple filters:
```
export interface Filter {
  state: string
  unitCount: number
  tables: {file: string; index: number; desc: string; units: string}[]
}

```