### PR TITLE
Fix map when 2 series one quarters, one without

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -215,11 +215,17 @@ export default function App(): JSX.Element {
     setTableForMap(0)
   }
 
-  const dataForYear = React.useMemo(() => data?.[tableForMap]?.filter((row) => row[1] === year), [
-    data,
-    year,
-    tableForMap,
-  ])
+  const dataForYear = React.useMemo(
+    () =>
+      year &&
+      data?.[tableForMap]?.filter((row) => {
+        if (row[1].includes('-') && year.includes('-')) {
+          return row[1] === year
+        }
+        return row[1].replace(/-.*$/, '') === year.replace(/-.*$/, '')
+      }),
+    [data, year, tableForMap]
+  )
 
   const [tooltipContent, setTooltipContent] = React.useState('')
 

--- a/src/LineChart.tsx
+++ b/src/LineChart.tsx
@@ -128,11 +128,13 @@ function LineChart({
 
   const isPercentage = data && data[0] && data[0][0][3] === '%'
   const padding = {top: 10, right: 50, bottom: 30, left: 50}
+  const usesQuarters = mainDomain.usesQuarters || altDomain.usesQuarters
+  const lastYear = Math.max(mainDomain.lastYear, altDomain.lastYear)
   return (
     <div ref={ref} style={{height: '100%'}}>
       {size && size.width && size.height && (
         <VictoryChart
-          key={`${mainDomain.usesQuarters}${mainDomain.lastYear}`}
+          key={`${usesQuarters}${lastYear}`}
           padding={padding}
           width={size.width}
           height={size.height}
@@ -143,12 +145,12 @@ function LineChart({
               allowResize={false}
               brushStyle={{stroke: 'transparent', fill: 'black', fillOpacity: 0.1}}
               brushDomain={{
-                x: mainDomain.usesQuarters
-                  ? [new Date(mainDomain.lastYear - 1, 10, 1), new Date(mainDomain.lastYear, 0, 1)]
-                  : [new Date(mainDomain.lastYear - 1, 1, 1), new Date(mainDomain.lastYear, 0, 1)],
+                x: usesQuarters
+                  ? [new Date(lastYear - 1, 10, 1), new Date(lastYear, 0, 1)]
+                  : [new Date(lastYear - 1, 1, 1), new Date(lastYear, 0, 1)],
               }}
               onBrushDomainChange={(domain) => {
-                if (mainDomain.usesQuarters) {
+                if (usesQuarters) {
                   const middle = new Date(
                     (domain.x[1].getTime() - domain.x[0].getTime()) / 2 + domain.x[0].getTime()
                   )

--- a/src/MapChart.tsx
+++ b/src/MapChart.tsx
@@ -85,8 +85,6 @@ function MapChart({setTooltipContent, filter, data}): JSX.Element {
     ReactTooltip.rebuild()
   })
 
-  if (!filteredData.length) return null
-
   return (
     <ComposableMap data-tip="" key={version} projection="geoAlbersUsa">
       <Geographies geography={geoUrl}>{states}</Geographies>


### PR DESCRIPTION
If you plotted data with quarters and without, the map would disappear when selecting the quarter dataset. This was becuase the year match failed.

Also show no data map in more cases